### PR TITLE
Update the list of exceptions

### DIFF
--- a/github/remove_external_collaborators.py
+++ b/github/remove_external_collaborators.py
@@ -34,7 +34,7 @@ def main():
         skip = any([
           repo.fork,
           repo.archived,
-          repo.name in ['process-models', 'infra-spiff-workflow', 'nim-raft', 'nim-eth-verkle'],
+          repo.name in ['process-models', 'infra-spiff-workflow', 'nim-raft', 'infra-lido'],
           '-ghsa-' in repo.name,
         ])
         if skip:


### PR DESCRIPTION
* `infra-lido` is added to the list due to the presence of external collaborators from the Metacraft Labs team.
* `nim-eth-verkle` is removed from the list because the external collaborators are now full-time Status CCs